### PR TITLE
Merge fixes

### DIFF
--- a/src/tablemerge/columns_aligner.py
+++ b/src/tablemerge/columns_aligner.py
@@ -12,7 +12,7 @@ class ColumnAligner:
     ):
         self.analyzers = analyzers
         self.max_sample = max_sample
-        self.mapping = self._build_mapping(left, right) if right is not None else {}
+        self.mapping = self._build_mapping(left, right)
 
     def rename_row(self, row: Row) -> Row:
         if not self.mapping:
@@ -27,15 +27,15 @@ class ColumnAligner:
         return self.mapping.get(col_name, col_name)
 
     def _build_mapping(
-        self, left: TableFragment, right: TableFragment
+        self, left: TableFragment, right: TableFragment | None
     ) -> dict[str, str]:
         left_rows = left.rows[: self.max_sample]
-        right_rows = right.rows[: self.max_sample]
-        if not left_rows or not right_rows:
+        right_rows = right.rows[: self.max_sample] if right is not None else []
+        if not left_rows:
             return {}
 
         remaining_left = left.get_column_names()
-        remaining_right = right.get_column_names()
+        remaining_right = right.get_column_names() if right is not None else []
         accumulated: dict[str, str] = {}
 
         for analyzer in self.analyzers:

--- a/src/tablemerge/merge.py
+++ b/src/tablemerge/merge.py
@@ -16,6 +16,8 @@ from tablemerge.columns_aligner import ColumnAligner
 from tablemerge.analyzers import Analyzer
 from tablemerge.fragment_transformer import NullFragmentTransformer, FragmentTransformer
 
+MergeTarget = tuple[TableFragment, TablesFile]
+
 
 def value_matches_header(column_name: str, value: ColumnValue) -> bool:
     normalized_name = normalize_str_value(column_name)
@@ -257,21 +259,21 @@ def merge_tablesfiles(
         # ==============================
 
         merged_fragments: list[TableFragment] = []
-        fragments_clusters = make_fragments_clusters(tables_cluster, transformer)
+        fragments_clusters = make_fragments_clusters(tables_cluster, tablesfiles, transformer)
 
-        for fragments_cluster in fragments_clusters.values():
+        for merge_targets in fragments_clusters.values():
 
             # =================================
             # Combine rows of the same fragment
             # =================================
 
             # TODO sort first so longest cluster is the first one
-            left_fragment = fragments_cluster[0]
+            left_fragment, left_tablesfile = merge_targets[0]
             if not left_fragment:
-                raise MergeError(f"no left fragment in {fragments_cluster}")
+                raise MergeError(f"no left fragment in {merge_targets}")
 
             first_right = next(
-                (f for f in fragments_cluster[1:] if f is not None), None
+                (f for f, _ in merge_targets[1:] if f is not None), None
             )
             aligner = ColumnAligner(
                 left_fragment,
@@ -285,14 +287,12 @@ def merge_tablesfiles(
 
             table_fragment_builder = TableFragmentBuilder(
                 left_fragment,
-                tablesfiles[0].uuid,
+                left_tablesfile.uuid,
                 agreement,
                 column_agreement,
             )
 
-            for right_fragment, right_tablesfile in zip(
-                fragments_cluster[1:], tablesfiles[1:]
-            ):
+            for right_fragment, right_tablesfile in merge_targets[1:]:
                 if not right_fragment:
                     break
 
@@ -351,15 +351,17 @@ def normalize_fragment(
 
 
 def make_fragments_clusters(
-    tables_cluster: Sequence[Table | None], transformer: FragmentTransformer
-):
-    fragments_clusters: dict[int, list[TableFragment]] = {}
-    for table in tables_cluster:
+    tables_cluster: Sequence[Table | None],
+    tablesfiles: Sequence[TablesFile],
+    transformer: FragmentTransformer,
+) -> dict[int, list[MergeTarget]]:
+    fragments_clusters: dict[int, list[MergeTarget]] = {}
+    for table, tablesfile in zip(tables_cluster, tablesfiles):
         if table is None:
             continue
         for fragment in table.get_table_fragments():
             fragments_clusters.setdefault(fragment.page, []).append(
-                normalize_fragment(fragment, transformer)
+                (normalize_fragment(fragment, transformer), tablesfile)
             )
     return fragments_clusters
 

--- a/src/tablemerge/merge.py
+++ b/src/tablemerge/merge.py
@@ -277,7 +277,7 @@ def merge_tablesfiles(
             )
             aligner = ColumnAligner(
                 left_fragment,
-                first_right if analyzers else None,
+                first_right,
                 analyzers=analyzers,
             )
             left_fragment = TableFragment(

--- a/src/utils/rows.py
+++ b/src/utils/rows.py
@@ -1,8 +1,14 @@
 import re
 
+# TODO handle other languages
+NO_DATA_EXPRESSIONS = {"no data", "none"}
+
 
 def normalize_str_value(value: str) -> str:
-    return re.sub(r"\s+", " ", value.strip()).lower()
+    normalized = re.sub(r"\s+", " ", value.strip()).lower()
+    if normalized in NO_DATA_EXPRESSIONS:
+        return ""
+    return normalized
 
 
 def _str_from_value(v) -> str:

--- a/tests/test_columns_aligner.py
+++ b/tests/test_columns_aligner.py
@@ -330,3 +330,15 @@ def test_column_aligner_jaccard_then_alias_transitivity():
         analyzers=[JaccardAnalyzer(), AliasAnalyzer({"family": "official_family"})],
     )
     assert aligner.mapping == {"0": "official_family", "family": "official_family"}
+
+
+def test_column_aligner_alias_applies_without_right_fragment():
+    left = wrap([Row(**{"familia": "Apiaceae"}), Row(**{"familia": "Rosaceae"})])
+    aligner = ColumnAligner(left, None, analyzers=[AliasAnalyzer({"familia": "family"})])
+    assert aligner.mapping == {"familia": "family"}
+
+
+def test_column_aligner_jaccard_no_op_without_right_fragment():
+    left = wrap([Row(**{"family": "Apiaceae"}), Row(**{"family": "Rosaceae"})])
+    aligner = ColumnAligner(left, None, analyzers=[JaccardAnalyzer()])
+    assert aligner.mapping == {}

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,7 +1,7 @@
 # pyright: reportCallIssue=false
 # pyright: reportArgumentType=false
 import pytest
-from tablemerge.analyzers import JaccardAnalyzer
+from tablemerge.analyzers import JaccardAnalyzer, AliasAnalyzer
 from tablemerge.merge import (
     merge_tablesfiles,
     merge_rows,
@@ -885,6 +885,30 @@ def test_filter_header_rows_preserves_citation_and_metadata():
     result = merge_tablesfiles([tablesfile])
     filtered = filter_header_rows(result)
     assert filtered.citation == "some citation"
+
+
+def test_alias_applies_with_single_tablesfile():
+    table = [Row(familia="Apiaceae", scientific_name="Ammi majus L.")]
+    result = merge_tablesfiles(
+        [wrap(table)], analyzers=[AliasAnalyzer({"familia": "family"})]
+    )
+    rows = result.tables[0].table_fragments[0].rows
+    assert rows == [Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)]
+
+
+def test_alias_applies_to_left_only_page_in_multi_file_merge():
+    # File A has page 1; file B has page 2 only. Page 1 has no right counterpart.
+    # The alias should still be applied to the left-only page 1 fragment.
+    table_a = [Row(familia="Apiaceae", scientific_name="Ammi majus L.")]
+    table_b = [Row(family="Rosaceae", scientific_name="Rosa canina L.")]
+    result = merge_tablesfiles(
+        [wrap(table_a, page=1), wrap(table_b, page=2)],
+        analyzers=[AliasAnalyzer({"familia": "family"})],
+    )
+    page1_rows = result.tables[0].table_fragments[0].rows
+    assert page1_rows == [
+        Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
+    ]
 
 
 def test_sources_correct_when_middle_tablesfile_is_on_different_page():

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -40,7 +40,7 @@ def test_single_table_returns_normalized():
 
     result = merge_tablesfiles([wrap(table)])
     assert len(result.tables) == 1
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
     ]
 
@@ -50,7 +50,7 @@ def test_single_table_with_row_agreement():
 
     result = merge_tablesfiles([wrap(table)], agreement=SimpleCountAgreement())
     assert len(result.tables) == 1
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
     ]
 
@@ -60,7 +60,7 @@ def test_two_identical_tables():
 
     result = merge_tablesfiles([wrap(table), wrap(table)])
     assert len(result.tables) == 1
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2)
     ]
 
@@ -72,7 +72,7 @@ def test_two_identical_tables_with_row_agreement():
         [wrap(table), wrap(table)], agreement=SimpleCountAgreement()
     )
     assert len(result.tables) == 1
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2)
     ]
 
@@ -82,7 +82,7 @@ def test_two_tables_with_non_normalized_columns():
     table_2 = [Row(family="apiaceae", scientific_name="ammi majus l.")]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2)
     ]
 
@@ -94,7 +94,7 @@ def test_two_tables_with_different_column_names_and_alignment():
     result = merge_tablesfiles(
         [wrap(table_1), wrap(table_2)], analyzers=[JaccardAnalyzer()]
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
     ]
 
@@ -106,7 +106,7 @@ def test_two_tables_with_different_column_names_and_no_alignment():
     result = merge_tablesfiles(
         [wrap(table_1), wrap(table_2)], agreement=SimpleCountAgreement()
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1),
         Row(
             agreement_level_=1, sources_=None, **{"0": "apiaceae", "1": "ammi majus l."}
@@ -121,7 +121,7 @@ def test_two_tables_with_different_values():
     ]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=1),
     ]
@@ -136,13 +136,13 @@ def test_two_tablesfiles_with_different_pages():
     result = merge_tablesfiles([wrap(table_1, page=1), wrap(table_2, page=2)])
     assert len(result.tables) == 1
 
-    assert result.tables[0].table_fragments[0].page == 1
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].page == 1
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1),
     ]
 
-    assert result.tables[0].table_fragments[1].page == 2
-    assert result.tables[0].table_fragments[1].rows == [
+    assert result.tables[0].get_table_fragments()[1].page == 2
+    assert result.tables[0].get_table_fragments()[1].rows == [
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=1),
     ]
 
@@ -155,7 +155,7 @@ def test_two_tables_with_mixed_values():
     ]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=1),
     ]
@@ -167,7 +167,7 @@ def test_three_tables_with_different_values():
     table_3 = [Row(family="Lamiaceae", scientific_name="Mentha spicata L.")]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2), wrap(table_3)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=1),
         Row(
@@ -190,7 +190,7 @@ def test_three_tables_with_overlapped_mixed_values():
     ]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2), wrap(table_3)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
         Row(
@@ -214,7 +214,7 @@ def test_three_tables_with_conflicting_values_without_row_agreement_level():
     ]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2), wrap(table_3)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="apiaceae", scientific_name="ammi", agreement_level_=1),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
@@ -235,7 +235,7 @@ def test_two_tables_with_conflicting_values_and_wrong_first_without_row_agreemen
     ]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi", agreement_level_=1),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=1),
         Row(
@@ -261,7 +261,7 @@ def test_three_tables_with_conflicting_values_and_wrong_first_without_row_agreem
     ]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2), wrap(table_3)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi", agreement_level_=1),
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
@@ -286,7 +286,7 @@ def test_three_tables_with_conflicting_values_and_wrong_in_the_middle_without_ro
     ]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2), wrap(table_3)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="apiaceae", scientific_name="ammi", agreement_level_=1),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
@@ -313,7 +313,7 @@ def test_three_tables_with_conflicting_values_with_row_agreement_level():
     result = merge_tablesfiles(
         [wrap(table_1), wrap(table_2), wrap(table_3)], agreement=SimpleCountAgreement()
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="apiaceae", scientific_name="ammi", agreement_level_=1),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
@@ -340,7 +340,7 @@ def xtest_three_tables_with_conflicting_values_with_column_agreement_level():
     result = merge_tablesfiles(
         [wrap(table_1), wrap(table_2), wrap(table_3)], column_agreement=True
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(
             family="apiaceae",
             scientific_name=[
@@ -407,14 +407,14 @@ def test_merge_different_rows_with_column_agreement():
 def test_sources_stamped_on_single_tablesfile():
     table = [Row(family="Apiaceae", scientific_name="Ammi majus L.")]
     result = merge_tablesfiles([wrap(table, uuid="uuid-a")])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert rows[0].sources_ == ["uuid-a"]
 
 
 def test_sources_merged_on_matched_rows():
     table = [Row(family="Apiaceae", scientific_name="Ammi majus L.")]
     result = merge_tablesfiles([wrap(table, uuid="uuid-a"), wrap(table, uuid="uuid-b")])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert rows[0].sources_ == ["uuid-a", "uuid-b"]
 
 
@@ -424,7 +424,7 @@ def test_sources_only_left_uuid_on_unmatched_left_row():
     result = merge_tablesfiles(
         [wrap(table_1, uuid="uuid-a"), wrap(table_2, uuid="uuid-b")]
     )
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert rows[0].sources_ == ["uuid-a"]
     assert rows[1].sources_ == ["uuid-b"]
 
@@ -438,7 +438,7 @@ def test_sources_right_uuid_on_skipped_row():
     result = merge_tablesfiles(
         [wrap(table_1, uuid="uuid-a"), wrap(table_2, uuid="uuid-b")]
     )
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     # "Rosaceae" was skipped (appears before the match in right table)
     rosaceae_row = next(r for r in rows if r.get_columns().get("family") == "rosaceae")
     assert rosaceae_row.sources_ == ["uuid-b"]
@@ -453,7 +453,7 @@ def test_two_tables_with_unicode_variant_values():
     table_2 = [Row(common_name="pezuña de vaca")]
 
     result = merge_tablesfiles([wrap(table_1), wrap(table_2)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(common_name="pezuña de vaca", agreement_level_=2)
     ]
 
@@ -461,14 +461,14 @@ def test_two_tables_with_unicode_variant_values():
 def test_sources_deduped_when_same_uuid_appears_twice():
     table = [Row(family="Apiaceae", scientific_name="Ammi majus L.")]
     result = merge_tablesfiles([wrap(table, uuid="uuid-a"), wrap(table, uuid="uuid-a")])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert rows[0].sources_ == ["uuid-a"]
 
 
 def test_sources_none_when_no_uuid_on_tablesfiles():
     table = [Row(family="Apiaceae", scientific_name="Ammi majus L.")]
     result = merge_tablesfiles([wrap(table), wrap(table)])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert rows[0].sources_ is None
 
 
@@ -521,7 +521,9 @@ def test_is_empty_row_value_with_agreement_all_empty():
 
 
 def test_is_empty_row_value_with_agreement_has_data():
-    assert not Row(family=[ValueWithAgreement(value="Apiaceae", agreement_level=1)]).is_empty()
+    assert not Row(
+        family=[ValueWithAgreement(value="Apiaceae", agreement_level=1)]
+    ).is_empty()
 
 
 def test_merge_filters_empty_rows_from_single_table():
@@ -530,7 +532,7 @@ def test_merge_filters_empty_rows_from_single_table():
         Row(family="", scientific_name=""),
     ]
     result = merge_tablesfiles([wrap(table)])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert len(rows) == 1
     assert rows[0].family == "apiaceae"
 
@@ -541,7 +543,7 @@ def test_merge_filters_whitespace_only_rows():
         Row(family="Rosaceae", scientific_name="Rosa"),
     ]
     result = merge_tablesfiles([wrap(table)])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert len(rows) == 1
     assert rows[0].family == "rosaceae"
 
@@ -550,7 +552,7 @@ def test_merge_filters_empty_rows_from_two_tables():
     table_1 = [Row(family="Apiaceae"), Row(family="")]
     table_2 = [Row(family="Apiaceae"), Row(family="")]
     result = merge_tablesfiles([wrap(table_1), wrap(table_2)])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert len(rows) == 1
     assert rows[0].family == "apiaceae"
 
@@ -561,7 +563,7 @@ def test_merge_keeps_rows_with_partial_data():
         Row(family="", scientific_name=""),
     ]
     result = merge_tablesfiles([wrap(table)])
-    rows = result.tables[0].table_fragments[0].rows
+    rows = result.tables[0].get_table_fragments()[0].rows
     assert len(rows) == 1
 
 
@@ -579,7 +581,7 @@ def test_filter_semantic_columns_removes_numeric():
     table = [Row(**{"family": "Apiaceae", "1": "yes", "2023": "data"})]
     result = merge_tablesfiles([wrap(table)])
     filtered = filter_semantic_columns(result)
-    rows = filtered.tables[0].table_fragments[0].rows
+    rows = filtered.tables[0].get_table_fragments()[0].rows
     assert len(rows) == 1
     assert rows[0].get_columns() == {"family": "apiaceae"}
 
@@ -588,7 +590,7 @@ def test_filter_semantic_columns_keeps_all_if_no_numeric():
     table = [Row(family="Apiaceae", scientific_name="Ammi majus")]
     result = merge_tablesfiles([wrap(table)])
     filtered = filter_semantic_columns(result)
-    rows = filtered.tables[0].table_fragments[0].rows
+    rows = filtered.tables[0].get_table_fragments()[0].rows
     assert len(rows) == 1
     assert set(rows[0].get_columns().keys()) == {"family", "scientific_name"}
 
@@ -644,7 +646,7 @@ def test_merge_two_tables_distinct_non_agent_readers():
         [wrap(table, uuid="uuid-1"), wrap(table, uuid="uuid-2")],
         agreement=agreement,
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(
             family="apiaceae",
             scientific_name="ammi majus l.",
@@ -663,7 +665,7 @@ def test_merge_two_tables_same_non_agent_reader():
         [wrap(table, uuid="uuid-1"), wrap(table, uuid="uuid-2")],
         agreement=agreement,
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(
             family="apiaceae",
             scientific_name="ammi majus l.",
@@ -680,7 +682,7 @@ def test_merge_two_tables_agent_and_non_agent_reader():
         [wrap(table, uuid="uuid-1"), wrap(table, uuid="uuid-2")],
         agreement=agreement,
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(
             family="apiaceae",
             scientific_name="ammi majus l.",
@@ -704,7 +706,7 @@ def test_merge_aligns_right_numeric_columns_multiple_rows():
     result = merge_tablesfiles(
         [wrap(table_1), wrap(table_2)], analyzers=[JaccardAnalyzer()]
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
         Row(
@@ -732,7 +734,7 @@ def test_merge_aligns_right_numeric_columns_with_agreement_multiple_rows():
         agreement=SimpleCountAgreement(),
         analyzers=[JaccardAnalyzer()],
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
         Row(
@@ -758,7 +760,7 @@ def test_merge_aligns_left_numeric_columns_multiple_rows():
     result = merge_tablesfiles(
         [wrap(table_1), wrap(table_2)], analyzers=[JaccardAnalyzer()]
     )
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=2),
         Row(
@@ -780,7 +782,7 @@ def test_merge_no_alignment_both_semantic_multiple_rows():
         Row(family="Lamiaceae", scientific_name="Mentha spicata L."),
     ]
     result = merge_tablesfiles([wrap(table_1), wrap(table_2)])
-    assert result.tables[0].table_fragments[0].rows == [
+    assert result.tables[0].get_table_fragments()[0].rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=2),
         Row(family="rosaceae", scientific_name="rosa canina l.", agreement_level_=1),
         Row(
@@ -850,7 +852,7 @@ def test_filter_header_rows_removes_header_row():
     ]
     result = merge_tablesfiles([wrap(table)])
     filtered = filter_header_rows(result)
-    rows = filtered.tables[0].table_fragments[0].rows
+    rows = filtered.tables[0].get_table_fragments()[0].rows
     assert rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
     ]
@@ -860,7 +862,7 @@ def test_filter_header_rows_keeps_data_rows():
     table = [Row(family="Apiaceae", scientific_name="Ammi majus L.")]
     result = merge_tablesfiles([wrap(table)])
     filtered = filter_header_rows(result)
-    rows = filtered.tables[0].table_fragments[0].rows
+    rows = filtered.tables[0].get_table_fragments()[0].rows
     assert rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
     ]
@@ -873,7 +875,7 @@ def test_filter_header_rows_with_partial_empty_cells():
     ]
     result = merge_tablesfiles([wrap(table)])
     filtered = filter_header_rows(result)
-    rows = filtered.tables[0].table_fragments[0].rows
+    rows = filtered.tables[0].get_table_fragments()[0].rows
     assert rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
     ]
@@ -892,8 +894,10 @@ def test_alias_applies_with_single_tablesfile():
     result = merge_tablesfiles(
         [wrap(table)], analyzers=[AliasAnalyzer({"familia": "family"})]
     )
-    rows = result.tables[0].table_fragments[0].rows
-    assert rows == [Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)]
+    rows = result.tables[0].get_table_fragments()[0].rows
+    assert rows == [
+        Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
+    ]
 
 
 def test_alias_applies_to_left_only_page_in_multi_file_merge():
@@ -905,7 +909,7 @@ def test_alias_applies_to_left_only_page_in_multi_file_merge():
         [wrap(table_a, page=1), wrap(table_b, page=2)],
         analyzers=[AliasAnalyzer({"familia": "family"})],
     )
-    page1_rows = result.tables[0].table_fragments[0].rows
+    page1_rows = result.tables[0].get_table_fragments()[0].rows
     assert page1_rows == [
         Row(family="apiaceae", scientific_name="ammi majus l.", agreement_level_=1)
     ]
@@ -920,13 +924,15 @@ def test_sources_correct_when_middle_tablesfile_is_on_different_page():
     row = [Row(family="Apiaceae", scientific_name="Ammi majus L.")]
     other_row = [Row(family="Rosaceae", scientific_name="Rosa canina L.")]
 
-    result = merge_tablesfiles([
-        wrap(row, page=1, uuid="uuid-a"),
-        wrap(other_row, page=2, uuid="uuid-b"),
-        wrap(row, page=1, uuid="uuid-c"),
-    ])
+    result = merge_tablesfiles(
+        [
+            wrap(row, page=1, uuid="uuid-a"),
+            wrap(other_row, page=2, uuid="uuid-b"),
+            wrap(row, page=1, uuid="uuid-c"),
+        ]
+    )
 
-    page1_rows = result.tables[0].table_fragments[0].rows
+    page1_rows = result.tables[0].get_table_fragments()[0].rows
     assert page1_rows == [
         Row(
             family="apiaceae",
@@ -936,7 +942,7 @@ def test_sources_correct_when_middle_tablesfile_is_on_different_page():
         )
     ]
 
-    page2_rows = result.tables[0].table_fragments[1].rows
+    page2_rows = result.tables[0].get_table_fragments()[1].rows
     assert page2_rows == [
         Row(
             family="rosaceae",

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -885,3 +885,39 @@ def test_filter_header_rows_preserves_citation_and_metadata():
     result = merge_tablesfiles([tablesfile])
     filtered = filter_header_rows(result)
     assert filtered.citation == "some citation"
+
+
+def test_sources_correct_when_middle_tablesfile_is_on_different_page():
+    # File A and C share page 1 with matching rows; file B is on page 2.
+    # The bug: make_fragments_clusters groups fragments by page and skips files
+    # that don't have that page, causing zip(fragments_cluster[1:], tablesfiles[1:])
+    # to misalign - C's fragment (index 1 in cluster) is paired with B's tablesfile,
+    # and B's fragment (sole entry on page 2) is attributed to tablesfiles[0].uuid.
+    row = [Row(family="Apiaceae", scientific_name="Ammi majus L.")]
+    other_row = [Row(family="Rosaceae", scientific_name="Rosa canina L.")]
+
+    result = merge_tablesfiles([
+        wrap(row, page=1, uuid="uuid-a"),
+        wrap(other_row, page=2, uuid="uuid-b"),
+        wrap(row, page=1, uuid="uuid-c"),
+    ])
+
+    page1_rows = result.tables[0].table_fragments[0].rows
+    assert page1_rows == [
+        Row(
+            family="apiaceae",
+            scientific_name="ammi majus l.",
+            agreement_level_=2,
+            sources_=["uuid-a", "uuid-c"],
+        )
+    ]
+
+    page2_rows = result.tables[0].table_fragments[1].rows
+    assert page2_rows == [
+        Row(
+            family="rosaceae",
+            scientific_name="rosa canina l.",
+            agreement_level_=1,
+            sources_=["uuid-b"],
+        )
+    ]

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -1,3 +1,5 @@
+# pyright: reportCallIssue=false
+
 from utils.rows import is_empty_value, normalize_str_value
 from tablevalidate.schema import Row, ValueWithAgreement
 

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -1,5 +1,33 @@
-from utils.rows import is_empty_value
+from utils.rows import is_empty_value, normalize_str_value
 from tablevalidate.schema import Row, ValueWithAgreement
+
+
+def test_normalize_str_value_no_data_lowercase():
+    assert normalize_str_value("no data") == ""
+
+
+def test_normalize_str_value_no_data_uppercase():
+    assert normalize_str_value("No Data") == ""
+
+
+def test_normalize_str_value_no_data_extra_whitespace():
+    assert normalize_str_value("  no  data  ") == ""
+
+
+def test_normalize_str_value_none():
+    assert normalize_str_value("None") == ""
+
+
+def test_normalize_str_value_regular_value():
+    assert normalize_str_value("Apiaceae") == "apiaceae"
+
+
+def test_is_empty_value_no_data_string():
+    assert is_empty_value("no data")
+
+
+def test_is_empty_value_no_data_uppercase():
+    assert is_empty_value("No Data")
 
 
 def test_is_empty_value_none():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,7 +29,7 @@ def wrap_two_tables(rows1: list[Row], rows2: list[Row], citation="") -> TablesFi
 
 
 def rows_of(tf: TablesFile, table=0, fragment=0):
-    return tf.tables[table].table_fragments[fragment].rows
+    return tf.tables[table].get_table_fragments()[fragment].rows
 
 
 


### PR DESCRIPTION
Prevent two bugs: 

1. Aliases don't run when there is only one fragment
2. Sources were incorrectly calculated when there were gaps in the sequence of fragments to be merged